### PR TITLE
fix: add php extensions required by portal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN add-apt-repository ppa:ondrej/php
 
 # Install PHP & Extensions
 RUN apt install -y php8.3 php8.3-cgi php8.3-cli php8.3-curl php8.3-dev php8.3-fpm php8.3-intl  \
-    php8.3-mbstring php8.3-mysql php8.3-opcache php8.3-pgsql php8.3-xml php8.3-zip
+    php8.3-mbstring php8.3-mysql php8.3-opcache php8.3-pgsql php8.3-xml php8.3-zip php8.3-bcmath \
+    php8.3-soap php8.3-gd php8.3-sqlite3
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
setup-php has decided that it can't install some extensions via apt and is instead trying to use pecl which is failing. It's nearly impossible to debug and I don't want to waste any more time on it.

We're only using it to install extensions for the ixport.al test workflow, so let's just do that via apt and get on with it. It might even make tests faster to have them installed the once instead of each run.